### PR TITLE
fix(tmLanguage): Adding injections and fixing keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "scopeName": "text.html.plush",
         "path": "./syntaxes/plush.tmLanguage.json",
         "embeddedLanguages": {
-          "text.html": "html",
+          "text.html meta.embedded.block.html meta.tag": "html",
           "source.css": "css",
           "source.js": "javascript"
         },

--- a/syntaxes/plush.tmLanguage.json
+++ b/syntaxes/plush.tmLanguage.json
@@ -3,14 +3,58 @@
     "name": "Plush",
     "scopeName": "text.html.plush",
     "fileTypes": ["html", "htm", "go-html", "plush"],
+    "injections": {
+		"text.html.plush, L:(source.css - (meta.embedded.block.plush | meta.embedded.line.plush))": {
+			"patterns": [
+				{
+					"include": "#keyword"
+				},
+                {
+                    "include": "#main"
+                }
+			]
+		}
+	},
     "patterns": [
         {
             "include": "text.html.basic"
         },
         {
             "include": "#block-comment"
+        }
+    ],
+    "repository": {
+        "block-comment": {
+            "begin": "<%#",
+            "captures": {
+                "0": {
+                    "name": "punctuation.definition.comment.begin.plush"
+                }
+            },
+            "end": "%>",
+            "name": "comment.block.plush",
+            "patterns": [
+                {
+                    "match": "[^%]>",
+                    "name": "invalid.illegal.characters-not-allowed-here.plush"
+                }
+            ]
         },
-        {
+        "line-comment": {
+            "patterns": [
+                {
+                    "begin": "#",
+                    "captures": {
+                        "0": {
+                            "name": "punctuation.definition.comment.begin.plush"
+                        }
+                    },
+                    "end": "$",
+                    "name": "comment.line.plush"
+                }
+            ]
+        },
+        "main":  {
             "begin": "(<%=|<%)",
             "beginCaptures": {
                 "0": {
@@ -48,43 +92,11 @@
                     "include": "text.html.basic"
                 }
             ]
-        }
-    ],
-    "repository": {
-        "block-comment": {
-            "begin": "<%#",
-            "captures": {
-                "0": {
-                    "name": "punctuation.definition.comment.begin.plush"
-                }
-            },
-            "end": "%>",
-            "name": "comment.block.plush",
-            "patterns": [
-                {
-                    "match": "[^%]>",
-                    "name": "invalid.illegal.characters-not-allowed-here.plush"
-                }
-            ]
-        },
-        "line-comment": {
-            "patterns": [
-                {
-                    "begin": "#",
-                    "captures": {
-                        "0": {
-                            "name": "punctuation.definition.comment.begin.plush"
-                        }
-                    },
-                    "end": "$",
-                    "name": "comment.line.plush"
-                }
-            ]
         },
         "keyword": {
             "patterns": [
                 {
-                    "match": "(?i)(function|let|if|else|return|for|in|fn|func)",
+                    "match": "(?i)(\bfunction\b|\blet\b|\bif\b|\belse\b|\breturn\b|\bfor\b|\bin\b|\bfn\b|\bfunc\b)",
                     "name": "keyword.plush"
                 },
                 {
@@ -137,7 +149,7 @@
                     "name": "string.quoted.other.plush"
                 },
                 {
-                    "match": "[0-9]",
+                    "match": "\b[0-9]\b",
                     "name": "constant.numeric.plush"
                 },
                 {


### PR DESCRIPTION
Hello! 

I found your extension and it's a great initiative. Thanks a lot for putting this together. 

I found some issues and I spend some time figuring out what was going on. 

- the keywords were being highlighted even when they were inside another word 
- if there was a plush line inside a quotation mark the syntax was lost. 

I added the html meta tags inside the embedded languages and added the plush injection inside html and css.

I also moved what defines a plush statement into a separate tag in the json.


This apparently solves the problems mentioned above.

Great extension and thanks again for the initiative 